### PR TITLE
chore: disable major version updates and add 3-day stabilization period

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,17 @@
     "integration-tests"
   ],
   "recreateWhen": "always",
+  "minimumReleaseAge": "3 days",
   "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
     {
       "matchPackagePatterns": [
         "*"


### PR DESCRIPTION
## Summary
- Disable major version updates to avoid breaking API changes from Renovate
- Add `minimumReleaseAge: 3 days` so we don't pull in brand-new releases immediately, reducing supply chain attack risk