### PR TITLE
feat: add Homebrew tap support for macOS installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -41,4 +41,5 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: npx semantic-release

--- a/.mise.toml
+++ b/.mise.toml
@@ -45,6 +45,14 @@ GOOS=linux GOARCH=arm64 go build -ldflags "$LDFLAGS" -o newsgoat-linux-arm64 .
 GOOS=darwin GOARCH=amd64 go build -ldflags "$LDFLAGS" -o newsgoat-darwin-amd64 .
 GOOS=darwin GOARCH=arm64 go build -ldflags "$LDFLAGS" -o newsgoat-darwin-arm64 .
 
+# Create tar.gz archives for Homebrew (binary renamed to "newsgoat" inside)
+for arch in amd64 arm64; do
+  tmpdir=$(mktemp -d)
+  cp "newsgoat-darwin-${arch}" "${tmpdir}/newsgoat"
+  tar czf "newsgoat-${VERSION}-darwin-${arch}.tar.gz" -C "${tmpdir}" newsgoat
+  rm -rf "${tmpdir}"
+done
+
 # Create checksums
 sha256sum newsgoat-* > checksums.txt
 """

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,7 +8,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "mise run build-release ${nextRelease.version}",
-        "publishCmd": "echo 'Version ${nextRelease.version} published'"
+        "publishCmd": "bash scripts/publish-homebrew.sh ${nextRelease.version}"
       }
     ],
     [
@@ -19,6 +19,8 @@
           {"path": "newsgoat-linux-arm64", "label": "newsgoat-linux-arm64"},
           {"path": "newsgoat-darwin-amd64", "label": "newsgoat-darwin-amd64"},
           {"path": "newsgoat-darwin-arm64", "label": "newsgoat-darwin-arm64"},
+          {"path": "newsgoat-*-darwin-amd64.tar.gz"},
+          {"path": "newsgoat-*-darwin-arm64.tar.gz"},
           {"path": "checksums.txt", "label": "checksums.txt"}
         ]
       }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,14 @@ git commit --no-verify
 
 ## Install
 
-### Quick Install (Recommended)
+### Homebrew (macOS)
+
+```bash
+brew tap jarv/newsgoat
+brew install newsgoat
+```
+
+### Quick Install
 
 Install with a single command (macOS and Linux):
 

--- a/scripts/newsgoat.rb.tmpl
+++ b/scripts/newsgoat.rb.tmpl
@@ -1,0 +1,24 @@
+class Newsgoat < Formula
+  desc "Terminal RSS/Atom feed reader"
+  homepage "https://github.com/jarv/newsgoat"
+  version "VERSION"
+  license "MIT"
+
+  on_arm do
+    url "https://github.com/jarv/newsgoat/releases/download/vVERSION/newsgoat-VERSION-darwin-arm64.tar.gz"
+    sha256 "SHA256_ARM64"
+  end
+
+  on_intel do
+    url "https://github.com/jarv/newsgoat/releases/download/vVERSION/newsgoat-VERSION-darwin-amd64.tar.gz"
+    sha256 "SHA256_AMD64"
+  end
+
+  def install
+    bin.install "newsgoat"
+  end
+
+  test do
+    assert_match "v#{version}", shell_output("#{bin}/newsgoat -version").strip
+  end
+end

--- a/scripts/publish-homebrew.sh
+++ b/scripts/publish-homebrew.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="$1"
+
+if [ -z "${HOMEBREW_TAP_TOKEN:-}" ]; then
+	echo "HOMEBREW_TAP_TOKEN is not set, skipping Homebrew formula update"
+	exit 0
+fi
+
+SHA256_ARM64=$(sha256sum "newsgoat-${VERSION}-darwin-arm64.tar.gz" | awk '{print $1}')
+SHA256_AMD64=$(sha256sum "newsgoat-${VERSION}-darwin-amd64.tar.gz" | awk '{print $1}')
+
+sed -e "s/VERSION/${VERSION}/g" \
+	-e "s/SHA256_ARM64/${SHA256_ARM64}/g" \
+	-e "s/SHA256_AMD64/${SHA256_AMD64}/g" \
+	scripts/newsgoat.rb.tmpl >newsgoat.rb
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/jarv/homebrew-newsgoat.git" "$TMPDIR"
+cp newsgoat.rb "$TMPDIR/newsgoat.rb"
+
+cd "$TMPDIR"
+git add newsgoat.rb
+git commit -m "newsgoat ${VERSION}"
+git push


### PR DESCRIPTION
## Summary
- Add Homebrew tap support so macOS users can install via `brew tap jarv/newsgoat && brew install newsgoat`
- Build pipeline now produces `.tar.gz` archives alongside raw binaries for Homebrew
- On each release, a formula is auto-published to [jarv/homebrew-newsgoat](https://github.com/jarv/homebrew-newsgoat)
- README updated with Homebrew install instructions

Closes #88

## Setup Required
A `HOMEBREW_TAP_TOKEN` repository secret (PAT with `repo` scope) must be added to this repo for the release workflow to push the formula to the tap repo. Without it, the Homebrew publish step is gracefully skipped.

## Files Changed
| File | Change |
|------|--------|
| `.mise.toml` | `build-release` now also creates darwin `.tar.gz` archives |
| `.releaserc.json` | Uploads archives + runs `publish-homebrew.sh` on release |
| `.github/workflows/release.yml` | Passes `HOMEBREW_TAP_TOKEN` secret, bumps Go to 1.25.8 |
| `scripts/newsgoat.rb.tmpl` | Homebrew formula template (macOS arm64/amd64) |
| `scripts/publish-homebrew.sh` | Generates formula from template and pushes to tap repo |
| `README.md` | Adds Homebrew install section |