### PR TITLE
feat: add regex-based filters for feeds and folders

### DIFF
--- a/internal/filters/filters.go
+++ b/internal/filters/filters.go
@@ -1,0 +1,275 @@
+package filters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jarv/newsgoat/internal/database"
+)
+
+const settingsKey = "filters"
+
+var validFields = map[string]bool{"URL": true, "Title": true, "Description": true}
+
+type Rule struct {
+	URL         []string `json:"URL,omitempty"`
+	Title       []string `json:"Title,omitempty"`
+	Description []string `json:"Description,omitempty"`
+}
+
+type FilterMap map[string]Rule
+
+type compiledPattern struct {
+	re     *regexp.Regexp
+	negate bool
+}
+
+type CompiledRule struct {
+	URL         []compiledPattern
+	Title       []compiledPattern
+	Description []compiledPattern
+}
+
+func Load(queries *database.Queries) (FilterMap, error) {
+	row, err := queries.GetSetting(context.Background(), settingsKey)
+	if err != nil {
+		return make(FilterMap), nil
+	}
+	fm, err := ParseJSON([]byte(row.Value))
+	if err != nil {
+		return make(FilterMap), err
+	}
+	return fm, nil
+}
+
+func Save(queries *database.Queries, fm FilterMap) error {
+	for k, r := range fm {
+		if len(r.URL) == 0 && len(r.Title) == 0 && len(r.Description) == 0 {
+			delete(fm, k)
+		}
+	}
+	if len(fm) == 0 {
+		return queries.DeleteSetting(context.Background(), settingsKey)
+	}
+	data, err := json.Marshal(fm)
+	if err != nil {
+		return err
+	}
+	return queries.SetSetting(context.Background(), database.SetSettingParams{
+		Key:   settingsKey,
+		Value: string(data),
+	})
+}
+
+func ParseJSON(data []byte) (FilterMap, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("invalid filter JSON: %w", err)
+	}
+	fm := make(FilterMap, len(raw))
+	for key, val := range raw {
+		if !isValidKey(key) {
+			return nil, fmt.Errorf("invalid filter key %q: must be \"global\", \"folder:<name>\", or \"feed:<id>\"", key)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(val, &fields); err != nil {
+			return nil, fmt.Errorf("invalid filter rule for %q: %w", key, err)
+		}
+		for field := range fields {
+			if !validFields[field] {
+				return nil, fmt.Errorf("invalid field %q in filter %q: allowed fields are URL, Title, Description", field, key)
+			}
+		}
+		var rule Rule
+		if err := json.Unmarshal(val, &rule); err != nil {
+			return nil, fmt.Errorf("invalid filter rule for %q: %w", key, err)
+		}
+		for _, patterns := range [][]string{rule.URL, rule.Title, rule.Description} {
+			for _, p := range patterns {
+				raw := strings.TrimPrefix(p, "!")
+				if _, err := regexp.Compile(raw); err != nil {
+					return nil, fmt.Errorf("invalid regex %q: %w", p, err)
+				}
+			}
+		}
+		fm[key] = rule
+	}
+	return fm, nil
+}
+
+func isValidKey(key string) bool {
+	if key == "global" {
+		return true
+	}
+	if strings.HasPrefix(key, "folder:") && len(key) > 7 {
+		return true
+	}
+	if strings.HasPrefix(key, "feed:") && len(key) > 5 {
+		return true
+	}
+	return false
+}
+
+func Compile(rule Rule) CompiledRule {
+	return CompiledRule{
+		URL:         compilePatterns(rule.URL),
+		Title:       compilePatterns(rule.Title),
+		Description: compilePatterns(rule.Description),
+	}
+}
+
+func compilePatterns(patterns []string) []compiledPattern {
+	out := make([]compiledPattern, 0, len(patterns))
+	for _, p := range patterns {
+		negate := false
+		raw := p
+		if strings.HasPrefix(raw, "!") {
+			negate = true
+			raw = raw[1:]
+		}
+		re, err := regexp.Compile(raw)
+		if err != nil {
+			continue
+		}
+		out = append(out, compiledPattern{re: re, negate: negate})
+	}
+	return out
+}
+
+func MatchItem(url, title, description string, rules []CompiledRule) bool {
+	for _, r := range rules {
+		if !matchField(url, r.URL) {
+			return false
+		}
+		if !matchField(title, r.Title) {
+			return false
+		}
+		if !matchField(description, r.Description) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchField(value string, patterns []compiledPattern) bool {
+	for _, p := range patterns {
+		matched := p.re.MatchString(value)
+		if p.negate && matched {
+			return false
+		}
+		if !p.negate && !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func RulesForFeed(fm FilterMap, feedID int64, folderNames []string) []Rule {
+	var rules []Rule
+	if r, ok := fm["global"]; ok {
+		rules = append(rules, r)
+	}
+	for _, folder := range folderNames {
+		if r, ok := fm["folder:"+folder]; ok {
+			rules = append(rules, r)
+		}
+	}
+	key := fmt.Sprintf("feed:%d", feedID)
+	if r, ok := fm[key]; ok {
+		rules = append(rules, r)
+	}
+	return rules
+}
+
+func CompileRules(rules []Rule) []CompiledRule {
+	out := make([]CompiledRule, len(rules))
+	for i, r := range rules {
+		out[i] = Compile(r)
+	}
+	return out
+}
+
+func HasActiveFilter(fm FilterMap, feedID int64, folderNames []string) bool {
+	return len(RulesForFeed(fm, feedID, folderNames)) > 0
+}
+
+func FeedKey(feedID int64) string {
+	return fmt.Sprintf("feed:%d", feedID)
+}
+
+func FolderKey(folderName string) string {
+	return "folder:" + folderName
+}
+
+func RuleToYAML(rule Rule, scopeLabel string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Filter for %s\n", scopeLabel)
+	b.WriteString("# Regexes are ANDed together. Prefix with ! to negate.\n")
+	b.WriteString("# Examples:\n")
+	b.WriteString("#   - \"golang\"        # items must match \"golang\"\n")
+	b.WriteString("#   - \"!/shorts/\"     # items must NOT match \"/shorts/\"\n")
+	b.WriteString("#\n")
+	writeYAMLField(&b, "URL", rule.URL)
+	writeYAMLField(&b, "Title", rule.Title)
+	writeYAMLField(&b, "Description", rule.Description)
+	return b.String()
+}
+
+func writeYAMLField(b *strings.Builder, name string, values []string) {
+	b.WriteString(name + ":\n")
+	for _, v := range values {
+		fmt.Fprintf(b, "  - %q\n", v)
+	}
+}
+
+func ParseYAML(content string) (Rule, error) {
+	var rule Rule
+	lines := strings.Split(content, "\n")
+	var currentField *[]string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasSuffix(trimmed, ":") {
+			field := strings.TrimSuffix(trimmed, ":")
+			switch field {
+			case "URL":
+				currentField = &rule.URL
+			case "Title":
+				currentField = &rule.Title
+			case "Description":
+				currentField = &rule.Description
+			default:
+				return Rule{}, fmt.Errorf("unknown field %q: allowed fields are URL, Title, Description", field)
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- ") {
+			if currentField == nil {
+				return Rule{}, fmt.Errorf("list item without a field header: %q", trimmed)
+			}
+			val := strings.TrimPrefix(trimmed, "- ")
+			val = strings.TrimSpace(val)
+			if (strings.HasPrefix(val, "\"") && strings.HasSuffix(val, "\"")) ||
+				(strings.HasPrefix(val, "'") && strings.HasSuffix(val, "'")) {
+				val = val[1 : len(val)-1]
+			}
+			raw := strings.TrimPrefix(val, "!")
+			if _, err := regexp.Compile(raw); err != nil {
+				return Rule{}, fmt.Errorf("invalid regex %q: %w", val, err)
+			}
+			*currentField = append(*currentField, val)
+			continue
+		}
+		return Rule{}, fmt.Errorf("unexpected line: %q", trimmed)
+	}
+	return rule, nil
+}
+
+func IsEmpty(rule Rule) bool {
+	return len(rule.URL) == 0 && len(rule.Title) == 0 && len(rule.Description) == 0
+}

--- a/internal/filters/filters_test.go
+++ b/internal/filters/filters_test.go
@@ -1,0 +1,221 @@
+package filters
+
+import (
+	"testing"
+)
+
+func TestParseJSON_Valid(t *testing.T) {
+	input := `{
+		"global": {"URL": ["golang"], "Title": ["!test"]},
+		"folder:Tech": {"Description": ["news"]},
+		"feed:42": {"URL": ["!/shorts/"]}
+	}`
+	fm, err := ParseJSON([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fm) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(fm))
+	}
+	if len(fm["global"].URL) != 1 || fm["global"].URL[0] != "golang" {
+		t.Errorf("unexpected global URL: %v", fm["global"].URL)
+	}
+	if len(fm["global"].Title) != 1 || fm["global"].Title[0] != "!test" {
+		t.Errorf("unexpected global Title: %v", fm["global"].Title)
+	}
+}
+
+func TestParseJSON_InvalidKey(t *testing.T) {
+	input := `{"badkey": {"URL": []}}`
+	_, err := ParseJSON([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for invalid key")
+	}
+}
+
+func TestParseJSON_InvalidField(t *testing.T) {
+	input := `{"global": {"BadField": ["x"]}}`
+	_, err := ParseJSON([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for invalid field")
+	}
+}
+
+func TestParseJSON_InvalidRegex(t *testing.T) {
+	input := `{"global": {"URL": ["[invalid"]}}`
+	_, err := ParseJSON([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+}
+
+func TestParseJSON_EmptyObject(t *testing.T) {
+	fm, err := ParseJSON([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fm) != 0 {
+		t.Fatalf("expected empty map, got %d entries", len(fm))
+	}
+}
+
+func TestMatchItem_NoRules(t *testing.T) {
+	if !MatchItem("url", "title", "desc", nil) {
+		t.Error("expected match with no rules")
+	}
+}
+
+func TestMatchItem_SimpleMatch(t *testing.T) {
+	rule := Compile(Rule{Title: []string{"golang"}})
+	if !MatchItem("", "I love golang", "", []CompiledRule{rule}) {
+		t.Error("expected match")
+	}
+	if MatchItem("", "I love python", "", []CompiledRule{rule}) {
+		t.Error("expected no match")
+	}
+}
+
+func TestMatchItem_Negation(t *testing.T) {
+	rule := Compile(Rule{URL: []string{"!/shorts/"}})
+	if !MatchItem("https://example.com/video", "", "", []CompiledRule{rule}) {
+		t.Error("expected match for non-shorts URL")
+	}
+	if MatchItem("https://example.com/shorts/123", "", "", []CompiledRule{rule}) {
+		t.Error("expected no match for shorts URL")
+	}
+}
+
+func TestMatchItem_MultiplePatterns_AND(t *testing.T) {
+	rule := Compile(Rule{Title: []string{"golang", "tutorial"}})
+	if !MatchItem("", "golang tutorial basics", "", []CompiledRule{rule}) {
+		t.Error("expected match when both patterns present")
+	}
+	if MatchItem("", "golang basics", "", []CompiledRule{rule}) {
+		t.Error("expected no match when only one pattern present")
+	}
+}
+
+func TestMatchItem_MultipleRules_AND(t *testing.T) {
+	r1 := Compile(Rule{Title: []string{"golang"}})
+	r2 := Compile(Rule{URL: []string{"!/shorts/"}})
+	if !MatchItem("https://example.com/post", "golang news", "", []CompiledRule{r1, r2}) {
+		t.Error("expected match")
+	}
+	if MatchItem("https://example.com/shorts/1", "golang news", "", []CompiledRule{r1, r2}) {
+		t.Error("expected no match due to URL negation")
+	}
+}
+
+func TestMatchItem_MultipleFields(t *testing.T) {
+	rule := Compile(Rule{
+		URL:   []string{"example\\.com"},
+		Title: []string{"news"},
+	})
+	if !MatchItem("https://example.com", "breaking news", "", []CompiledRule{rule}) {
+		t.Error("expected match")
+	}
+	if MatchItem("https://other.com", "breaking news", "", []CompiledRule{rule}) {
+		t.Error("expected no match due to URL mismatch")
+	}
+}
+
+func TestRulesForFeed(t *testing.T) {
+	fm := FilterMap{
+		"global":      {URL: []string{"x"}},
+		"folder:Tech": {Title: []string{"y"}},
+		"feed:42":     {Description: []string{"z"}},
+	}
+	rules := RulesForFeed(fm, 42, []string{"Tech", "Science"})
+	if len(rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(rules))
+	}
+
+	rules = RulesForFeed(fm, 99, []string{"Other"})
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule (global only), got %d", len(rules))
+	}
+}
+
+func TestRuleToYAML_RoundTrip(t *testing.T) {
+	rule := Rule{
+		URL:         []string{"!/shorts/"},
+		Title:       []string{"golang", "tutorial"},
+		Description: []string{},
+	}
+	yaml := RuleToYAML(rule, "test feed")
+	parsed, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error parsing YAML: %v", err)
+	}
+	if len(parsed.URL) != 1 || parsed.URL[0] != "!/shorts/" {
+		t.Errorf("URL mismatch: %v", parsed.URL)
+	}
+	if len(parsed.Title) != 2 {
+		t.Errorf("Title mismatch: %v", parsed.Title)
+	}
+	if len(parsed.Description) != 0 {
+		t.Errorf("Description should be empty: %v", parsed.Description)
+	}
+}
+
+func TestParseYAML_Empty(t *testing.T) {
+	rule, err := ParseYAML("# just comments\nURL:\nTitle:\nDescription:\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !IsEmpty(rule) {
+		t.Error("expected empty rule")
+	}
+}
+
+func TestParseYAML_InvalidField(t *testing.T) {
+	_, err := ParseYAML("BadField:\n  - \"x\"\n")
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}
+
+func TestParseYAML_InvalidRegex(t *testing.T) {
+	_, err := ParseYAML("URL:\n  - \"[invalid\"\n")
+	if err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+}
+
+func TestParseYAML_ListWithoutHeader(t *testing.T) {
+	_, err := ParseYAML("  - \"orphan\"\n")
+	if err == nil {
+		t.Fatal("expected error for list item without header")
+	}
+}
+
+func TestHasActiveFilter(t *testing.T) {
+	fm := FilterMap{"feed:42": {Title: []string{"x"}}}
+	if !HasActiveFilter(fm, 42, nil) {
+		t.Error("expected active filter for feed 42")
+	}
+	if HasActiveFilter(fm, 99, nil) {
+		t.Error("expected no active filter for feed 99")
+	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	if !IsEmpty(Rule{}) {
+		t.Error("expected empty")
+	}
+	if IsEmpty(Rule{Title: []string{"x"}}) {
+		t.Error("expected not empty")
+	}
+}
+
+func TestFeedKey(t *testing.T) {
+	if FeedKey(42) != "feed:42" {
+		t.Error("unexpected key")
+	}
+}
+
+func TestFolderKey(t *testing.T) {
+	if FolderKey("Tech") != "folder:Tech" {
+		t.Error("unexpected key")
+	}
+}

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jarv/newsgoat/internal/database"
 	"github.com/jarv/newsgoat/internal/discovery"
 	"github.com/jarv/newsgoat/internal/feeds"
+	"github.com/jarv/newsgoat/internal/filters"
 	"github.com/jarv/newsgoat/internal/logging"
 	"github.com/jarv/newsgoat/internal/tasks"
 )
@@ -559,5 +560,78 @@ func performSearch(feedManager *feeds.Manager, viewState ViewState, feedID int64
 		}
 
 		return SearchResultsMsg{}
+	}
+}
+
+func openFilterInEditor(fm filters.FilterMap, scope string, scopeLabel string) tea.Cmd {
+	editor := config.GetEditor()
+	if editor == "" {
+		return func() tea.Msg {
+			return FilterEditorErrorMsg{Err: "EDITOR environment variable is not set"}
+		}
+	}
+
+	return func() tea.Msg {
+		rule := fm[scope]
+		content := filters.RuleToYAML(rule, scopeLabel)
+
+		tmpFile, err := os.CreateTemp("", "newsgoat-filter-*.yaml")
+		if err != nil {
+			return FilterEditorErrorMsg{Err: "Failed to create temp file: " + err.Error()}
+		}
+		tmpPath := tmpFile.Name()
+
+		if _, err := tmpFile.WriteString(content); err != nil {
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpPath)
+			return FilterEditorErrorMsg{Err: "Failed to write temp file: " + err.Error()}
+		}
+		_ = tmpFile.Close()
+
+		c := exec.Command(editor, tmpPath)
+		return tea.ExecProcess(c, func(err error) tea.Msg {
+			if err != nil {
+				_ = os.Remove(tmpPath)
+				return FilterEditorErrorMsg{Err: "Failed to open editor: " + err.Error()}
+			}
+			return FilterEditorFinishedMsg{Scope: scope, TempFilePath: tmpPath}
+		})()
+	}
+}
+
+func computeFilteredCounts(feedManager *feeds.Manager, fm filters.FilterMap) tea.Cmd {
+	return func() tea.Msg {
+		if len(fm) == 0 {
+			return FilteredCountsMsg{}
+		}
+		stats, err := feedManager.GetFeedStats()
+		if err != nil {
+			logging.Error("computeFilteredCounts: failed to get feed stats", "error", err)
+			return FilteredCountsMsg{}
+		}
+		counts := make(map[int64]int64, len(stats))
+		for _, feed := range stats {
+			folders, _ := feedManager.GetFeedFolders(feed.ID)
+			rules := filters.RulesForFeed(fm, feed.ID, folders)
+			if len(rules) == 0 {
+				continue
+			}
+			compiled := filters.CompileRules(rules)
+			items, err := feedManager.GetItemsWithReadStatus(feed.ID)
+			if err != nil {
+				continue
+			}
+			var unread int64
+			for _, item := range items {
+				if item.Read {
+					continue
+				}
+				if filters.MatchItem(item.Link, item.Title, item.Description, compiled) {
+					unread++
+				}
+			}
+			counts[feed.ID] = unread
+		}
+		return FilteredCountsMsg{Counts: counts}
 	}
 }

--- a/internal/ui/keybindings.go
+++ b/internal/ui/keybindings.go
@@ -29,9 +29,10 @@ var GlobalKeys = []KeyBinding{
 
 // View-specific key bindings
 var FeedListViewKeys = ViewKeyBindings{
-	AllowedKeys: []string{"r", "R", "l", "t", "c", "U", "u", "i", "/", "ctrl+f"},
+	AllowedKeys: []string{"r", "R", "l", "t", "c", "U", "u", "i", "f", "F", "/", "ctrl+f"},
 	StatusBar: []KeyBinding{
 		{"/", "search"},
+		{"f", "filter"},
 		{"c", "config"},
 		{"r/R", "reload"},
 	},

--- a/internal/ui/models.go
+++ b/internal/ui/models.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/jarv/newsgoat/internal/database"
 	"github.com/jarv/newsgoat/internal/discovery"
 	"github.com/jarv/newsgoat/internal/feeds"
+	"github.com/jarv/newsgoat/internal/filters"
 	"github.com/jarv/newsgoat/internal/logging"
 	"github.com/jarv/newsgoat/internal/tasks"
 	"github.com/jarv/newsgoat/internal/themes"
@@ -229,6 +231,8 @@ type Model struct {
 	ctrlCPressed                    bool                                 // Track if 'ctrl+c' was pressed once (for quit confirmation)
 	addingURL                       bool                                 // Track if in URL adding mode
 	urlInput                        string                               // Current URL input text
+	filterMap                       filters.FilterMap
+	filteredUnreadCounts            map[int64]int64
 }
 
 type RefreshMsg struct {
@@ -333,6 +337,19 @@ type RestartReloadTimerMsg struct{}
 
 type CountdownTickMsg struct{}
 
+type FilterEditorFinishedMsg struct {
+	Scope        string
+	TempFilePath string
+}
+
+type FilterEditorErrorMsg struct {
+	Err string
+}
+
+type FilteredCountsMsg struct {
+	Counts map[int64]int64
+}
+
 // createGlamourRenderer creates a glamour renderer with the given theme
 // and configures it to hide link URLs (since we add [1], [2] markers manually)
 func createGlamourRenderer(themeName string) (*glamour.TermRenderer, error) {
@@ -394,7 +411,18 @@ func NewModel(feedManager *feeds.Manager, taskManager tasks.Manager, queries *da
 		pendingStartupReload: cfg.ReloadOnStartup, // Will trigger reload after feed list loads
 		expandedFolders:      make(map[string]bool),
 		folderStats:          make(map[string]struct{ UnreadItems, TotalItems int64 }),
+		filterMap:            loadFiltersSync(queries),
+		filteredUnreadCounts: make(map[int64]int64),
 	}
+}
+
+func loadFiltersSync(queries *database.Queries) filters.FilterMap {
+	fm, err := filters.Load(queries)
+	if err != nil {
+		logging.Error("Failed to load filters", "error", err)
+		return make(filters.FilterMap)
+	}
+	return fm
 }
 
 func (m Model) Init() tea.Cmd {
@@ -403,6 +431,10 @@ func (m Model) Init() tea.Cmd {
 		loadFeedList(m.feedManager),
 		listenForTaskEvents(m.taskManager),
 	)
+
+	if len(m.filterMap) > 0 {
+		cmds = append(cmds, computeFilteredCounts(m.feedManager, m.filterMap))
+	}
 
 	// Start the reload timer if auto reload is enabled
 	if m.config.AutoReload && m.config.ReloadTime > 0 {
@@ -488,17 +520,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Note: if not in FeedListView, don't modify cursor or savedFeedCursor
 		// They will be set appropriately when we transition back to FeedListView
 
-		// Trigger reload on startup if configured and this is the first load
 		if m.pendingStartupReload && len(m.allFeeds) > 0 {
 			m.pendingStartupReload = false
 			return m, func() tea.Msg { return ReloadTimerMsg{} }
+		}
+
+		if len(m.filterMap) > 0 {
+			return m, computeFilteredCounts(m.feedManager, m.filterMap)
 		}
 
 		return m, nil
 
 	case ItemListLoadedMsg:
 		m.itemList = msg.Items
-		m.currentFeed = msg.Feed // Cache feed info for rendering
+		m.currentFeed = msg.Feed
+
+		if len(m.filterMap) > 0 {
+			folders, _ := m.feedManager.GetFeedFolders(msg.Feed.ID)
+			rules := filters.RulesForFeed(m.filterMap, msg.Feed.ID, folders)
+			if len(rules) > 0 {
+				compiled := filters.CompileRules(rules)
+				filtered := make([]database.GetItemsWithReadStatusRow, 0, len(m.itemList))
+				for _, item := range m.itemList {
+					if filters.MatchItem(item.Link, item.Title, item.Description, compiled) {
+						filtered = append(filtered, item)
+					}
+				}
+				m.itemList = filtered
+			}
+		}
 
 		if m.state == ItemListView {
 			// Preserve cursor position when refreshing
@@ -602,8 +652,55 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, syncFeedsFromTempFile(m.feedManager, msg.TempFilePath)
 
 	case EditorErrorMsg:
-		// Display error message
 		m.err = fmt.Errorf("%s", msg.Err)
+		return m, nil
+
+	case FilterEditorFinishedMsg:
+		content, err := os.ReadFile(msg.TempFilePath)
+		_ = os.Remove(msg.TempFilePath)
+		if err != nil {
+			m.statusMessage = "Failed to read filter file: " + err.Error()
+			m.statusMessageType = "error"
+			return m, nil
+		}
+		rule, err := filters.ParseYAML(string(content))
+		if err != nil {
+			m.statusMessage = "Invalid filter: " + err.Error()
+			m.statusMessageType = "error"
+			return m, nil
+		}
+		if filters.IsEmpty(rule) {
+			delete(m.filterMap, msg.Scope)
+		} else {
+			m.filterMap[msg.Scope] = rule
+		}
+		ruleJSON, err := json.Marshal(m.filterMap)
+		if err == nil {
+			if _, err := filters.ParseJSON(ruleJSON); err != nil {
+				m.statusMessage = "Filter validation failed: " + err.Error()
+				m.statusMessageType = "error"
+				return m, nil
+			}
+		}
+		if err := filters.Save(m.queries, m.filterMap); err != nil {
+			m.statusMessage = "Failed to save filter: " + err.Error()
+			m.statusMessageType = "error"
+			return m, nil
+		}
+		m.statusMessage = "Filter updated"
+		m.statusMessageType = "info"
+		return m, computeFilteredCounts(m.feedManager, m.filterMap)
+
+	case FilterEditorErrorMsg:
+		m.statusMessage = msg.Err
+		m.statusMessageType = "error"
+		return m, nil
+
+	case FilteredCountsMsg:
+		m.filteredUnreadCounts = msg.Counts
+		if m.filteredUnreadCounts == nil {
+			m.filteredUnreadCounts = make(map[int64]int64)
+		}
 		return m, nil
 
 	case FeedInfoLoadedMsg:
@@ -1356,14 +1453,37 @@ func (m Model) handleFeedListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "U":
-		// Check if EDITOR is set
 		if config.GetEditor() == "" {
 			m.statusMessage = "Set EDITOR in your env to edit urls"
 			m.statusMessageType = "error"
 			return m, nil
 		}
-		// Open URLs file in editor
 		return m, openURLsFileInEditor(m.feedManager)
+
+	case "f":
+		if config.GetEditor() == "" {
+			m.statusMessage = "Set EDITOR in your env to edit filters"
+			m.statusMessageType = "error"
+			return m, nil
+		}
+		if len(m.feedList) > 0 && m.cursor < len(m.feedList) {
+			item := m.feedList[m.cursor]
+			if item.IsFolder {
+				scope := filters.FolderKey(item.FolderName)
+				return m, openFilterInEditor(m.filterMap, scope, "folder: "+item.FolderName)
+			} else if item.Feed != nil {
+				scope := filters.FeedKey(item.Feed.ID)
+				return m, openFilterInEditor(m.filterMap, scope, item.Feed.Title)
+			}
+		}
+
+	case "F":
+		if config.GetEditor() == "" {
+			m.statusMessage = "Set EDITOR in your env to edit filters"
+			m.statusMessageType = "error"
+			return m, nil
+		}
+		return m, openFilterInEditor(m.filterMap, "global", "Global")
 
 	case "i":
 		// Show feed info (only for feeds, not folders)
@@ -1918,6 +2038,48 @@ func (m Model) getUnreadStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
 }
 
+func (m Model) renderOrangeCount(unread, total int64) string {
+	orangeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
+	unreadStr := orangeStyle.Render(fmt.Sprintf("%d", unread))
+	countStr := fmt.Sprintf("(%s/%d)", unreadStr, total)
+	plainLen := len(fmt.Sprintf("(%d/%d)", unread, total))
+	pad := 9 - plainLen
+	if pad < 0 {
+		pad = 0
+	}
+	return strings.Repeat(" ", pad) + countStr
+}
+
+func (m Model) folderHasFilter(folderName string) bool {
+	if _, ok := m.filterMap[filters.FolderKey(folderName)]; ok {
+		return true
+	}
+	if _, ok := m.filterMap["global"]; ok {
+		return true
+	}
+	return false
+}
+
+func (m Model) filteredFolderUnread(folderName string) int64 {
+	var total int64
+	for _, item := range m.feedList {
+		if !item.IsFolder && item.IsUnderFolder && item.Feed != nil {
+			folders, _ := m.feedManager.GetFeedFolders(item.Feed.ID)
+			for _, f := range folders {
+				if f == folderName {
+					if count, ok := m.filteredUnreadCounts[item.Feed.ID]; ok {
+						total += count
+					} else {
+						total += item.Feed.UnreadItems
+					}
+					break
+				}
+			}
+		}
+	}
+	return total
+}
+
 // buildFeedDisplayList creates a flat list of folders and feeds for display
 func (m *Model) buildFeedDisplayList(feeds []database.GetFeedStatsRow) {
 	// Group feeds by folders
@@ -2218,16 +2380,22 @@ func (m Model) renderFeedList() string {
 			} else {
 				folderIcon = "📁" // Closed folder
 			}
-			countStr := fmt.Sprintf("(%d/%d)", item.UnreadItems, item.TotalItems)
+			hasFilter := m.folderHasFilter(item.FolderName)
+			unread := item.UnreadItems
+			if hasFilter {
+				unread = m.filteredFolderUnread(item.FolderName)
+			}
+			countStr := fmt.Sprintf("(%d/%d)", unread, item.TotalItems)
 			paddedCount := fmt.Sprintf("%9s", countStr)
-			// Add 2 spaces after emoji to align with feed items (which have statusEmoji + 2-char spinner)
+			if hasFilter && i != m.cursor {
+				paddedCount = m.renderOrangeCount(unread, item.TotalItems)
+			}
 			line = folderIcon + "  " + paddedCount + " " + item.FolderName
 
-			// Apply highlighting
 			if i == m.cursor {
 				line = m.applyHighlight(line, true)
 			} else {
-				if item.UnreadItems > 0 {
+				if unread > 0 {
 					line = m.getUnreadStyle().Render(line)
 				}
 				line = m.applyHighlight(line, false)
@@ -2270,14 +2438,20 @@ func (m Model) renderFeedList() string {
 				spinner = "  " // Two spaces when not spinning
 			}
 
-			// Count string right-justified to 9 characters
-			countStr := fmt.Sprintf("(%d/%d)", feed.UnreadItems, feed.TotalItems)
+			feedFiltered := len(m.filteredUnreadCounts) > 0
+			_, hasFeedFilter := m.filteredUnreadCounts[feed.ID]
+			unread := feed.UnreadItems
+			if hasFeedFilter {
+				unread = m.filteredUnreadCounts[feed.ID]
+			}
+			countStr := fmt.Sprintf("(%d/%d)", unread, feed.TotalItems)
 			paddedCount := fmt.Sprintf("%9s", countStr)
+			if feedFiltered && hasFeedFilter && i != m.cursor {
+				paddedCount = m.renderOrangeCount(unread, feed.TotalItems)
+			}
 
-			// Get display title - override for GitHub and GitLab feeds
 			displayTitle := getDisplayTitle(feed)
 
-			// Add vertical bar prefix if this feed is under a folder
 			var prefix string
 			if item.IsUnderFolder {
 				prefix = "│ "
@@ -2285,14 +2459,12 @@ func (m Model) renderFeedList() string {
 				prefix = ""
 			}
 
-			// Construct the line: prefix + status emoji (if error) + spinner (2 chars) + count (9 chars) + space + feed title
 			line = prefix + statusEmoji + spinner + paddedCount + " " + displayTitle
 
-			// Apply highlighting
 			if i == m.cursor {
 				line = m.applyHighlight(line, true)
 			} else {
-				if feed.UnreadItems > 0 {
+				if unread > 0 {
 					line = m.getUnreadStyle().Render(line)
 				}
 				line = m.applyHighlight(line, false)
@@ -3143,6 +3315,8 @@ func (m Model) renderHelpView() string {
 	fmt.Fprintf(&content, "  %-15s %s\n", "ctrl+f", "Title search only")
 	fmt.Fprintf(&content, "  %-15s %s\n", "u", "Add URL (with discovery)")
 	fmt.Fprintf(&content, "  %-15s %s\n", "U", "Edit URLs in $EDITOR")
+	fmt.Fprintf(&content, "  %-15s %s\n", "f", "Edit filter for feed/folder in $EDITOR")
+	fmt.Fprintf(&content, "  %-15s %s\n", "F", "Edit global filter in $EDITOR")
 	fmt.Fprintf(&content, "  %-15s %s\n", "ctrl+r", "Reload URLs from file")
 	fmt.Fprintf(&content, "  %-15s %s\n", "l", "View logs")
 	fmt.Fprintf(&content, "  %-15s %s\n", "t", "View tasks")


### PR DESCRIPTION
## Summary
Add a filtering system that lets users define regex patterns to control which items are displayed in feeds and folders.

### How it works
- **`f`** on a feed/folder → opens `$EDITOR` with a YAML template to define URL/Title/Description regex filters
- **`F`** → opens `$EDITOR` for the global filter (applies to all feeds)
- Filters are ANDed: global → folder → feed all apply together
- Prefix with `!` to negate (e.g. `!/shorts/` hides items with `/shorts/` in URL)
- Filtered unread counts display in **orange** in the feed list
- Items not matching active filters are hidden from the item list view
- Saving an empty filter removes it
- Filter JSON is validated (schema + regex syntax) before storing in the DB

### YAML format
```yaml
URL:
  - "!/shorts/"
Title:
  - "golang"
Description:
```

### Files
| File | Change |
|------|--------|
| `internal/filters/filters.go` | **New** — filter data model, YAML/JSON parsing, regex matching, validation |
| `internal/filters/filters_test.go` | **New** — 21 tests covering matching, negation, parsing, validation |
| `internal/ui/commands.go` | Filter editor commands + filtered count computation |
| `internal/ui/models.go` | Filter state, key handlers, item filtering, orange count rendering |
| `internal/ui/keybindings.go` | Add `f`/`F` keys to feed list view |