### PR TITLE
feat: add OPML import command

### DIFF
--- a/internal/opml/opml.go
+++ b/internal/opml/opml.go
@@ -1,0 +1,103 @@
+package opml
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/jarv/newsgoat/internal/config"
+)
+
+type document struct {
+	XMLName xml.Name `xml:"opml"`
+	Body    body     `xml:"body"`
+}
+
+type body struct {
+	Outlines []outline `xml:"outline"`
+}
+
+type outline struct {
+	Text     string    `xml:"text,attr"`
+	Title    string    `xml:"title,attr"`
+	XMLURL   string    `xml:"xmlUrl,attr"`
+	Outlines []outline `xml:"outline"`
+}
+
+func (o outline) displayName() string {
+	if o.Title != "" {
+		return o.Title
+	}
+	return o.Text
+}
+
+func Parse(data []byte) ([]config.URLEntry, error) {
+	var doc document
+	if err := xml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("invalid OPML: %w", err)
+	}
+
+	var entries []config.URLEntry
+	seen := make(map[string]bool)
+
+	var walk func(outlines []outline, folder string)
+	walk = func(outlines []outline, folder string) {
+		for _, o := range outlines {
+			if o.XMLURL != "" {
+				u := strings.TrimSpace(o.XMLURL)
+				if u == "" || seen[u] {
+					continue
+				}
+				seen[u] = true
+				var folders []string
+				if folder != "" {
+					folders = []string{folder}
+				}
+				entries = append(entries, config.URLEntry{
+					URL:     u,
+					Folders: folders,
+				})
+			}
+			if len(o.Outlines) > 0 {
+				name := o.displayName()
+				if o.XMLURL == "" && name != "" {
+					walk(o.Outlines, name)
+				} else {
+					walk(o.Outlines, folder)
+				}
+			}
+		}
+	}
+
+	walk(doc.Body.Outlines, "")
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no feeds found in OPML file")
+	}
+
+	return entries, nil
+}
+
+func ReadSource(source string) ([]byte, error) {
+	u, err := url.Parse(source)
+	if err == nil && u.Host != "" && u.Scheme != "" {
+		resp, err := http.Get(source)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch OPML from URL: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to fetch OPML: HTTP %d", resp.StatusCode)
+		}
+		return io.ReadAll(resp.Body)
+	}
+	data, err := os.ReadFile(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read OPML file: %w", err)
+	}
+	return data, nil
+}

--- a/internal/opml/opml_test.go
+++ b/internal/opml/opml_test.go
@@ -1,0 +1,210 @@
+package opml
+
+import (
+	"testing"
+)
+
+func TestParse_FlatFeeds(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline text="Feed A" type="rss" xmlUrl="https://a.com/feed"/>
+    <outline text="Feed B" type="rss" xmlUrl="https://b.com/feed"/>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].URL != "https://a.com/feed" {
+		t.Errorf("unexpected URL: %s", entries[0].URL)
+	}
+	if len(entries[0].Folders) != 0 {
+		t.Errorf("expected no folders, got %v", entries[0].Folders)
+	}
+}
+
+func TestParse_NestedFolders(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline title="Tech" text="Tech">
+      <outline text="Ars" type="rss" xmlUrl="https://ars.com/feed"/>
+      <outline text="Verge" type="rss" xmlUrl="https://verge.com/feed"/>
+    </outline>
+    <outline title="News">
+      <outline text="BBC" type="rss" xmlUrl="https://bbc.com/feed"/>
+    </outline>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+	if entries[0].Folders[0] != "Tech" {
+		t.Errorf("expected folder Tech, got %v", entries[0].Folders)
+	}
+	if entries[2].Folders[0] != "News" {
+		t.Errorf("expected folder News, got %v", entries[2].Folders)
+	}
+}
+
+func TestParse_DeepNesting(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline title="Level1">
+      <outline title="Level2">
+        <outline text="Deep" type="rss" xmlUrl="https://deep.com/feed"/>
+      </outline>
+    </outline>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Folders[0] != "Level2" {
+		t.Errorf("expected folder Level2 (immediate parent), got %v", entries[0].Folders)
+	}
+}
+
+func TestParse_DuplicateURLs(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline text="Feed A" xmlUrl="https://a.com/feed"/>
+    <outline text="Feed A Copy" xmlUrl="https://a.com/feed"/>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry after dedup, got %d", len(entries))
+	}
+}
+
+func TestParse_MissingXMLURL(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline title="Empty Folder"/>
+    <outline text="Feed" xmlUrl="https://a.com/feed"/>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+}
+
+func TestParse_PrefersTitleOverText(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline title="My Title" text="My Text">
+      <outline text="Feed" xmlUrl="https://a.com/feed"/>
+    </outline>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entries[0].Folders[0] != "My Title" {
+		t.Errorf("expected folder 'My Title', got %v", entries[0].Folders)
+	}
+}
+
+func TestParse_FallsBackToText(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline text="Only Text">
+      <outline text="Feed" xmlUrl="https://a.com/feed"/>
+    </outline>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entries[0].Folders[0] != "Only Text" {
+		t.Errorf("expected folder 'Only Text', got %v", entries[0].Folders)
+	}
+}
+
+func TestParse_NoFeeds(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline title="Empty"/>
+  </body>
+</opml>`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error for OPML with no feeds")
+	}
+}
+
+func TestParse_InvalidXML(t *testing.T) {
+	_, err := Parse([]byte("not xml"))
+	if err == nil {
+		t.Fatal("expected error for invalid XML")
+	}
+}
+
+func TestParse_AtomType(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline text="Atom Feed" type="atom" xmlUrl="https://atom.com/feed"/>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+}
+
+func TestParse_MixedFolderAndRootFeeds(t *testing.T) {
+	data := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <body>
+    <outline text="Root Feed" xmlUrl="https://root.com/feed"/>
+    <outline title="Tech">
+      <outline text="Nested" xmlUrl="https://nested.com/feed"/>
+    </outline>
+  </body>
+</opml>`)
+	entries, err := Parse(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if len(entries[0].Folders) != 0 {
+		t.Errorf("root feed should have no folders, got %v", entries[0].Folders)
+	}
+	if entries[1].Folders[0] != "Tech" {
+		t.Errorf("nested feed should have folder Tech, got %v", entries[1].Folders)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jarv/newsgoat/internal/discovery"
 	"github.com/jarv/newsgoat/internal/feeds"
 	"github.com/jarv/newsgoat/internal/logging"
+	"github.com/jarv/newsgoat/internal/opml"
 	"github.com/jarv/newsgoat/internal/tasks"
 	"github.com/jarv/newsgoat/internal/ui"
 	"github.com/jarv/newsgoat/internal/version"
@@ -38,7 +39,8 @@ func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: newsgoat [options] [command]\n\n")
 		fmt.Fprintf(os.Stderr, "Commands:\n")
-		fmt.Fprintf(os.Stderr, "  add <url>    Add a feed URL to the database\n\n")
+		fmt.Fprintf(os.Stderr, "  add <url>          Add a feed URL to the database\n")
+		fmt.Fprintf(os.Stderr, "  import <file|url>  Import feeds from an OPML file\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nEnvironment Variables:\n")
@@ -77,6 +79,17 @@ func main() {
 				os.Exit(1)
 			}
 			if err := addURL(args[1]); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "import":
+			if len(args) < 2 {
+				fmt.Fprintf(os.Stderr, "Error: 'import' command requires a file path or URL\n")
+				fmt.Fprintf(os.Stderr, "Usage: newsgoat import <file|url>\n")
+				os.Exit(1)
+			}
+			if err := importOPML(args[1]); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
@@ -127,6 +140,82 @@ func addURL(urlArg string) error {
 	}
 
 	fmt.Printf("Successfully added feed: %s\n", feedURL)
+	return nil
+}
+
+func importOPML(source string) error {
+	data, err := opml.ReadSource(source)
+	if err != nil {
+		return err
+	}
+
+	entries, err := opml.Parse(data)
+	if err != nil {
+		return err
+	}
+
+	db, queries, err := database.InitDBWithSchema(schemaSQL)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	defer func() {
+		_ = db.Close()
+	}()
+
+	if err := RunMigrations(db); err != nil {
+		return fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	feedManager := feeds.NewManager(db, queries)
+
+	allFeeds, err := feedManager.GetAllFeeds()
+	if err != nil {
+		return fmt.Errorf("failed to get existing feeds: %w", err)
+	}
+	existingURLs := make(map[string]database.Feed, len(allFeeds))
+	for _, f := range allFeeds {
+		existingURLs[f.Url] = f
+	}
+
+	var added, skipped, unhidden int
+	for _, entry := range entries {
+		if existing, ok := existingURLs[entry.URL]; ok {
+			if !existing.Visible {
+				if err := feedManager.ShowFeedByURL(entry.URL); err != nil {
+					fmt.Fprintf(os.Stderr, "  Warning: failed to unhide %s: %v\n", entry.URL, err)
+				} else {
+					unhidden++
+				}
+			} else {
+				skipped++
+			}
+			continue
+		}
+		if err := feedManager.AddFeedWithoutFetching(entry.URL); err != nil {
+			fmt.Fprintf(os.Stderr, "  Warning: failed to add %s: %v\n", entry.URL, err)
+			continue
+		}
+		if len(entry.Folders) > 0 {
+			feed, err := feedManager.GetFeedByURL(entry.URL)
+			if err == nil {
+				for _, folder := range entry.Folders {
+					_ = feedManager.AddFeedFolder(feed.ID, folder)
+				}
+			}
+		}
+		added++
+	}
+
+	fmt.Printf("Importing from: %s\n", source)
+	fmt.Printf("  Found %d feeds in OPML file\n", len(entries))
+	if skipped > 0 {
+		fmt.Printf("  %d already exist (skipped)\n", skipped)
+	}
+	if unhidden > 0 {
+		fmt.Printf("  %d were hidden and are now visible\n", unhidden)
+	}
+	fmt.Printf("  %d new feeds added\n", added)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Add `newsgoat import <file|url>` CLI command to import feeds from OPML files.

### Behavior
- **Additive only** — existing feeds are never removed or hidden
- **Duplicate URLs** are skipped
- **Hidden feeds** found in the OPML are made visible again
- **Folder assignments** from OPML nested outline structure are applied to new feeds
- Supports both **local file paths** and **remote URLs**

### Example
```
$ newsgoat import feeds.opml
Importing from: feeds.opml
  Found 23 feeds in OPML file
  3 already exist (skipped)
  2 were hidden and are now visible
  18 new feeds added
```

### Files
| File | Change |
|------|--------|
| `internal/opml/opml.go` | **New** — OPML XML parsing, URL/file source reading |
| `internal/opml/opml_test.go` | **New** — 11 tests covering flat feeds, nested folders, dedup, edge cases |
| `main.go` | Add `import` subcommand, `importOPML()` function, update usage text |